### PR TITLE
0.5.0 added scala configuration for GenBBackend, using 2.10.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
-  - 2.10.5
+  - 2.10.6
 script: "sbt compile"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here's an example for configuring a `build.sbt` file:
     // Use `devConfig` to set the scalacOptions, javacOptions, and incOptions settings.
     scalaVersion := "2.11.7"
     CompileScalaJava.librarySettings(devConfig)
-    // `librarySettings` sets up cross compilation for 2.11.7 and 2.10.5.
+    // `librarySettings` sets up cross compilation for 2.11.7 and 2.10.6.
     // If doing plugin development, use `CompileScalaJava.pluginSettings`,
     // which ensures that we're using only 2.10 and not cross compiling.
     

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 // GAV coordinates
 organization := "com.gonitro"
 name         := "sbt-dev-settings"
-version      := "0.4.0"
+version      := "0.5.0"
 
 // sbt plugins must be at Scala 2.10.x
 //
-scalaVersion := "2.10.5"
+scalaVersion := "2.10.6"
 sbtPlugin    := true
 description  := "sbt plugin for standardizing compilation, packaging, formatting, and publishing configurations"
 

--- a/src/main/scala/com/nitro/build/CompileScalaJava.scala
+++ b/src/main/scala/com/nitro/build/CompileScalaJava.scala
@@ -15,12 +15,13 @@ object CompileScalaJava {
     logImplicits:  Boolean,
     optimize:      Boolean,
     crossCompile:  Seq[String],
-    inlineWarn:    Boolean
+    inlineWarn:    Boolean,
+    genBBackend:   Boolean
   )
 
   object ScalaConfig {
 
-    val cross = Seq("2.10.5", "2.11.7")
+    val cross = Seq("2.10.6", "2.11.7")
 
     val default: ScalaConfig =
       ScalaConfig(
@@ -28,7 +29,8 @@ object CompileScalaJava {
         logImplicits = false,
         optimize = true,
         crossCompile = cross,
-        inlineWarn = true
+        inlineWarn = true,
+        genBBackend = true
       )
   }
 
@@ -83,11 +85,11 @@ object CompileScalaJava {
   }
 
   /**
-   * [mutation!] Sets scalaVersion to 2.10.5
+   * [mutation!] Sets scalaVersion to 2.10.6
    * Ignores any crossCompile settings in the input Config, c.
    */
   def pluginSettings(c: Config = Config.plugin) = {
-    scalaVersion := "2.10.5"
+    scalaVersion := "2.10.6"
     val updatedC = c.copy(scala =
       c.scala.copy(crossCompile = Seq.empty[String]))
     settings(updatedC) ++ Seq(sbtPlugin := true)
@@ -98,7 +100,7 @@ object CompileScalaJava {
    * (scala 2.11 with base settings and cross-compilation to 2.10).
    *
    * Note. Unlike plugin(), this does not mutate scalaVersion. It does
-   * make sure that c.scala.crossCompile == (2.10.5, 2.11.7)
+   * make sure that c.scala.crossCompile == (2.10.6, 2.11.7)
    */
   def librarySettings(c: Config = Config.default) = {
     val updatedC = c.copy(scala =
@@ -197,7 +199,7 @@ object CompileScalaJava {
         .addOption(c.scala.logImplicits, "-Xlog-implicits")
         // use an optimized bytecode generator
         // only applicable in Scala 2.11 (not available in 2.10, default in 2.12)
-        .addOption(isScala211(scalaVersion.value), "-Ybackend:GenBCode")
+        .addOption(c.scala.genBBackend && isScala211(scalaVersion.value), "-Ybackend:GenBCode")
         // Emit warnings when things tagged @inline cannot be inlined
         .addOption(c.scala.inlineWarn, "-Yinline-warnings")
     }


### PR DESCRIPTION
* Using default configuration keeps same behavior, i.e. use -GenBBackend if scala version == 2.11.x
* Updated to both use 2.10.6 and have settings use 2.10.6.